### PR TITLE
Set up Spring Boot backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # clean-helper
+
+A self-hosted household planner that tracks the realistic effort of chores. The application learns how much "energy" each user spends on different tasks and suggests a weekly energy budget to avoid burnout.
+
+## Features
+
+- Calendar view with tasks and optional Google Calendar overlay (read-only).
+- Per-user weekly energy budget that adapts over time.
+- Task energy learning using recent history (median or EWMA).
+- End-of-week reports highlighting over/under estimates.
+- Spring Boot + SQLite backend; React frontend (planned).
+
+## Building
+
+```bash
+mvn test
+```
+
+This will compile the Spring Boot backend and run the test suite (if present).

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.cleanhelper</groupId>
+    <artifactId>clean-helper</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>clean-helper</name>
+    <description>Self-hosted household planner</description>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/cleanhelper/CleanHelperApplication.java
+++ b/src/main/java/com/cleanhelper/CleanHelperApplication.java
@@ -1,0 +1,12 @@
+package com.cleanhelper;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CleanHelperApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CleanHelperApplication.class, args);
+    }
+}

--- a/src/main/java/com/cleanhelper/model/EnergyProfile.java
+++ b/src/main/java/com/cleanhelper/model/EnergyProfile.java
@@ -1,0 +1,58 @@
+package com.cleanhelper.model;
+
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+public class EnergyProfile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private User user;
+
+    @ManyToOne(optional = false)
+    private TaskType taskType;
+
+    private Double predictedCost;
+
+    @ElementCollection
+    private List<Integer> historyWindow;
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public TaskType getTaskType() {
+        return taskType;
+    }
+
+    public void setTaskType(TaskType taskType) {
+        this.taskType = taskType;
+    }
+
+    public Double getPredictedCost() {
+        return predictedCost;
+    }
+
+    public void setPredictedCost(Double predictedCost) {
+        this.predictedCost = predictedCost;
+    }
+
+    public List<Integer> getHistoryWindow() {
+        return historyWindow;
+    }
+
+    public void setHistoryWindow(List<Integer> historyWindow) {
+        this.historyWindow = historyWindow;
+    }
+}

--- a/src/main/java/com/cleanhelper/model/Task.java
+++ b/src/main/java/com/cleanhelper/model/Task.java
@@ -1,0 +1,93 @@
+package com.cleanhelper.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Entity
+public class Task {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String description;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+
+    @Enumerated(EnumType.STRING)
+    private TaskStatus status = TaskStatus.SCHEDULED;
+
+    @ManyToMany
+    @JoinTable(name = "task_assignees",
+            joinColumns = @JoinColumn(name = "task_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private Set<User> assignees;
+
+    @ManyToOne
+    private TaskType taskType;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public TaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TaskStatus status) {
+        this.status = status;
+    }
+
+    public Set<User> getAssignees() {
+        return assignees;
+    }
+
+    public void setAssignees(Set<User> assignees) {
+        this.assignees = assignees;
+    }
+
+    public TaskType getTaskType() {
+        return taskType;
+    }
+
+    public void setTaskType(TaskType taskType) {
+        this.taskType = taskType;
+    }
+}

--- a/src/main/java/com/cleanhelper/model/TaskCompletion.java
+++ b/src/main/java/com/cleanhelper/model/TaskCompletion.java
@@ -1,0 +1,67 @@
+package com.cleanhelper.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+public class TaskCompletion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Task task;
+
+    @ManyToOne(optional = false)
+    private User user;
+
+    private Integer actualCost;
+
+    private LocalDateTime completedAt;
+
+    private boolean exceptional;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    public void setTask(Task task) {
+        this.task = task;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Integer getActualCost() {
+        return actualCost;
+    }
+
+    public void setActualCost(Integer actualCost) {
+        this.actualCost = actualCost;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(LocalDateTime completedAt) {
+        this.completedAt = completedAt;
+    }
+
+    public boolean isExceptional() {
+        return exceptional;
+    }
+
+    public void setExceptional(boolean exceptional) {
+        this.exceptional = exceptional;
+    }
+}

--- a/src/main/java/com/cleanhelper/model/TaskStatus.java
+++ b/src/main/java/com/cleanhelper/model/TaskStatus.java
@@ -1,0 +1,6 @@
+package com.cleanhelper.model;
+
+public enum TaskStatus {
+    SCHEDULED,
+    COMPLETED
+}

--- a/src/main/java/com/cleanhelper/model/TaskType.java
+++ b/src/main/java/com/cleanhelper/model/TaskType.java
@@ -1,0 +1,25 @@
+package com.cleanhelper.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class TaskType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/cleanhelper/model/User.java
+++ b/src/main/java/com/cleanhelper/model/User.java
@@ -1,0 +1,59 @@
+package com.cleanhelper.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    private Integer weeklyEnergyCap;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public Integer getWeeklyEnergyCap() {
+        return weeklyEnergyCap;
+    }
+
+    public void setWeeklyEnergyCap(Integer weeklyEnergyCap) {
+        this.weeklyEnergyCap = weeklyEnergyCap;
+    }
+}

--- a/src/main/java/com/cleanhelper/repository/EnergyProfileRepository.java
+++ b/src/main/java/com/cleanhelper/repository/EnergyProfileRepository.java
@@ -1,0 +1,12 @@
+package com.cleanhelper.repository;
+
+import com.cleanhelper.model.EnergyProfile;
+import com.cleanhelper.model.TaskType;
+import com.cleanhelper.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EnergyProfileRepository extends JpaRepository<EnergyProfile, Long> {
+    Optional<EnergyProfile> findByUserAndTaskType(User user, TaskType taskType);
+}

--- a/src/main/java/com/cleanhelper/repository/TaskCompletionRepository.java
+++ b/src/main/java/com/cleanhelper/repository/TaskCompletionRepository.java
@@ -1,0 +1,7 @@
+package com.cleanhelper.repository;
+
+import com.cleanhelper.model.TaskCompletion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskCompletionRepository extends JpaRepository<TaskCompletion, Long> {
+}

--- a/src/main/java/com/cleanhelper/repository/TaskRepository.java
+++ b/src/main/java/com/cleanhelper/repository/TaskRepository.java
@@ -1,0 +1,7 @@
+package com.cleanhelper.repository;
+
+import com.cleanhelper.model.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+}

--- a/src/main/java/com/cleanhelper/repository/TaskTypeRepository.java
+++ b/src/main/java/com/cleanhelper/repository/TaskTypeRepository.java
@@ -1,0 +1,7 @@
+package com.cleanhelper.repository;
+
+import com.cleanhelper.model.TaskType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskTypeRepository extends JpaRepository<TaskType, Long> {
+}

--- a/src/main/java/com/cleanhelper/repository/UserRepository.java
+++ b/src/main/java/com/cleanhelper/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.cleanhelper.repository;
+
+import com.cleanhelper.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:sqlite:cleanhelper.db
+spring.datasource.driver-class-name=org.sqlite.JDBC
+spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- add Maven-based Spring Boot backend with SQLite configuration
- define domain entities for users, tasks, energy profiles, and completions
- provide JPA repositories and placeholder application class

## Testing
- `mvn test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1c37debc8320bc6729af4049680e