### PR TITLE
Add JWT login and calendar API key endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,23 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.45.2.0</version>

--- a/src/main/java/com/cleanhelper/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cleanhelper/config/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.cleanhelper.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        final String authHeader = request.getHeader("Authorization");
+        String username = null;
+        String token = null;
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            token = authHeader.substring(7);
+            try {
+                username = jwtUtil.extractUsername(token);
+            } catch (Exception ignored) {
+            }
+        }
+
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+            if (jwtUtil.isTokenValid(token)) {
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}
+

--- a/src/main/java/com/cleanhelper/config/JwtUtil.java
+++ b/src/main/java/com/cleanhelper/config/JwtUtil.java
@@ -1,0 +1,57 @@
+package com.cleanhelper.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private Key getKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generateToken(String username) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + 1000 * 60 * 60 * 10); // 10 hours
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(getKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String extractUsername(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}
+

--- a/src/main/java/com/cleanhelper/config/SecurityConfig.java
+++ b/src/main/java/com/cleanhelper/config/SecurityConfig.java
@@ -2,30 +2,43 @@ package com.cleanhelper.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.http.HttpMethod;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-            .csrf().disable()
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS))
+        http.csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers(HttpMethod.POST, "/users").permitAll()
-                .anyRequest().authenticated()
+                    .requestMatchers(HttpMethod.POST, "/users").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/login").permitAll()
+                    .anyRequest().authenticated()
             )
-            .formLogin(form -> form.permitAll())
-            .logout(logout -> logout.permitAll());
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
     }
 
     @Bean

--- a/src/main/java/com/cleanhelper/controller/AuthController.java
+++ b/src/main/java/com/cleanhelper/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.cleanhelper.controller;
+
+import com.cleanhelper.config.JwtUtil;
+import com.cleanhelper.dto.LoginRequest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    public AuthController(AuthenticationManager authenticationManager, JwtUtil jwtUtil) {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @PostMapping("/login")
+    public Map<String, String> login(@RequestBody LoginRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));
+        String token = jwtUtil.generateToken(authentication.getName());
+        return Map.of("token", token);
+    }
+}
+

--- a/src/main/java/com/cleanhelper/controller/CalendarController.java
+++ b/src/main/java/com/cleanhelper/controller/CalendarController.java
@@ -1,28 +1,22 @@
 package com.cleanhelper.controller;
 
-import com.cleanhelper.dto.TaskDTO;
-import com.cleanhelper.service.TaskService;
-import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/calendar")
 public class CalendarController {
-    private final TaskService taskService;
 
-    public CalendarController(TaskService taskService) {
-        this.taskService = taskService;
-    }
+    @Value("${google.api.key}")
+    private String googleApiKey;
 
-    @GetMapping
-    public List<TaskDTO> getTasks(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-                                  @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end) {
-        return taskService.findByDateRange(start, end);
+    @GetMapping("/api-key")
+    public Map<String, String> getApiKey() {
+        return Map.of("apiKey", googleApiKey);
     }
 }
+

--- a/src/main/java/com/cleanhelper/controller/UserController.java
+++ b/src/main/java/com/cleanhelper/controller/UserController.java
@@ -1,13 +1,7 @@
 package com.cleanhelper.controller;
 
 import com.cleanhelper.dto.UserDTO;
-
 import com.cleanhelper.dto.UserInputDTO;
-
-
-import com.cleanhelper.dto.UserInputDTO;
-
-
 import com.cleanhelper.service.UserService;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/cleanhelper/dto/LoginRequest.java
+++ b/src/main/java/com/cleanhelper/dto/LoginRequest.java
@@ -1,0 +1,23 @@
+package com.cleanhelper.dto;
+
+public class LoginRequest {
+    private String username;
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}
+

--- a/src/main/java/com/cleanhelper/service/UserService.java
+++ b/src/main/java/com/cleanhelper/service/UserService.java
@@ -66,8 +66,5 @@ public class UserService {
         dto.setWeeklyEnergyCap(user.getWeeklyEnergyCap());
         return dto;
     }
-
-}
-
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,5 @@ spring.datasource.url=jdbc:sqlite:cleanhelper.db
 spring.datasource.driver-class-name=org.sqlite.JDBC
 spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
 spring.jpa.hibernate.ddl-auto=update
+jwt.secret=Q2hhbmdlVGhpc1NlY3JldEtleUNoYW5nZVRoaXNTZWNyZXRLZXk=
+google.api.key=YOUR_GOOGLE_API_KEY


### PR DESCRIPTION
## Summary
- replace calendar controller with endpoint exposing Google API key
- add JWT-based authentication with login endpoint and security filter
- use base64-encoded secret and guard token parsing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*
