### PR TITLE
Fetch calendar events without exposing API key

### DIFF
--- a/src/main/java/com/cleanhelper/controller/CalendarController.java
+++ b/src/main/java/com/cleanhelper/controller/CalendarController.java
@@ -1,22 +1,30 @@
 package com.cleanhelper.controller;
 
-import org.springframework.beans.factory.annotation.Value;
+import com.cleanhelper.service.CalendarService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
+/**
+ * Controller responsible for exposing calendar information.
+ * Instead of leaking the API key, it fetches the user's calendar
+ * via the Google Calendar API and returns the events.
+ */
 @RestController
 @RequestMapping("/calendar")
 public class CalendarController {
 
-    @Value("${google.api.key}")
-    private String googleApiKey;
+    private final CalendarService calendarService;
 
-    @GetMapping("/api-key")
-    public Map<String, String> getApiKey() {
-        return Map.of("apiKey", googleApiKey);
+    public CalendarController(CalendarService calendarService) {
+        this.calendarService = calendarService;
+    }
+
+    @GetMapping("/events")
+    public Map<String, Object> getCalendarEvents() {
+        return calendarService.getCalendarEvents();
     }
 }
 

--- a/src/main/java/com/cleanhelper/service/CalendarService.java
+++ b/src/main/java/com/cleanhelper/service/CalendarService.java
@@ -1,0 +1,42 @@
+package com.cleanhelper.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Service responsible for retrieving calendar information from the
+ * Google Calendar API using the configured API key. The API key is
+ * used only on the server side and is never exposed to the client.
+ */
+@Service
+public class CalendarService {
+
+    @Value("${google.api.key}")
+    private String googleApiKey;
+
+    private final RestTemplate restTemplate;
+
+    public CalendarService(RestTemplateBuilder restTemplateBuilder) {
+        this.restTemplate = restTemplateBuilder.build();
+    }
+
+    /**
+     * Fetches the user's primary calendar events from Google Calendar.
+     *
+     * @return a map containing the events or an error message if the
+     *         events could not be retrieved
+     */
+    public Map<String, Object> getCalendarEvents() {
+        String url = "https://www.googleapis.com/calendar/v3/calendars/primary/events?key=" + googleApiKey;
+        try {
+            return restTemplate.getForObject(url, Map.class);
+        } catch (Exception ex) {
+            return Collections.singletonMap("error", "Unable to fetch calendar events");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace API key endpoint with calendar events retrieval
- Add CalendarService to call Google Calendar API using server-side key

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
