### PR TITLE
feat: integrate google oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ mvn test
 ```
 
 This will compile the Spring Boot backend and run the test suite (if present).
+
+## Google OAuth Setup
+
+To enable Google Calendar integration the application uses OAuth 2.0.
+Create an OAuth consent screen and a desktop OAuth client ID in the
+[Google Cloud Console](https://console.cloud.google.com/). Download the
+client credentials JSON and point the application to it via the
+`GOOGLE_CREDENTIALS_FILE` environment variable.

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,23 @@
             <artifactId>hibernate-community-dialects</artifactId>
         </dependency>
 
+        <!-- Google OAuth and Calendar API -->
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>1.34.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.oauth-client</groupId>
+            <artifactId>google-oauth-client-jetty</artifactId>
+            <version>1.34.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-calendar</artifactId>
+            <version>v3-rev305-1.25.0</version>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/cleanhelper/service/CalendarService.java
+++ b/src/main/java/com/cleanhelper/service/CalendarService.java
@@ -1,28 +1,62 @@
 package com.cleanhelper.service;
 
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
+import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.store.FileDataStoreFactory;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.CalendarScopes;
+import com.google.api.services.calendar.model.Events;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
+import java.io.FileReader;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
  * Service responsible for retrieving calendar information from the
- * Google Calendar API using the configured API key. The API key is
- * used only on the server side and is never exposed to the client.
+ * Google Calendar API using OAuth 2.0 credentials. Access and refresh
+ * tokens are stored locally and automatically refreshed when needed.
  */
 @Service
 public class CalendarService {
 
-    @Value("${google.api.key}")
-    private String googleApiKey;
+    private static final String APPLICATION_NAME = "Clean Helper";
+    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final List<String> SCOPES = List.of(CalendarScopes.CALENDAR_READONLY);
 
-    private final RestTemplate restTemplate;
+    private final String credentialsFile;
 
-    public CalendarService(RestTemplateBuilder restTemplateBuilder) {
-        this.restTemplate = restTemplateBuilder.build();
+    public CalendarService(@Value("${google.credentials.file}") String credentialsFile) {
+        this.credentialsFile = credentialsFile;
+    }
+
+    private Credential authorize(NetHttpTransport httpTransport) throws IOException {
+        GoogleClientSecrets clientSecrets =
+                GoogleClientSecrets.load(JSON_FACTORY, new FileReader(credentialsFile));
+
+        GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(
+                httpTransport, JSON_FACTORY, clientSecrets, SCOPES)
+                .setDataStoreFactory(new FileDataStoreFactory(new java.io.File("tokens")))
+                .setAccessType("offline")
+                .build();
+
+        Credential credential = flow.loadCredential("user");
+        if (credential != null) {
+            return credential;
+        }
+        LocalServerReceiver receiver = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receiver).authorize("user");
     }
 
     /**
@@ -32,11 +66,18 @@ public class CalendarService {
      *         events could not be retrieved
      */
     public Map<String, Object> getCalendarEvents() {
-        String url = "https://www.googleapis.com/calendar/v3/calendars/primary/events?key=" + googleApiKey;
         try {
-            return restTemplate.getForObject(url, Map.class);
-        } catch (Exception ex) {
+            NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+            Credential credential = authorize(httpTransport);
+            Calendar service = new Calendar.Builder(httpTransport, JSON_FACTORY, credential)
+                    .setApplicationName(APPLICATION_NAME)
+                    .build();
+
+            Events events = service.events().list("primary").execute();
+            return Map.of("items", events.getItems());
+        } catch (GeneralSecurityException | IOException ex) {
             return Collections.singletonMap("error", "Unable to fetch calendar events");
         }
     }
 }
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,5 +3,6 @@ spring.datasource.driver-class-name=org.sqlite.JDBC
 spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
 spring.jpa.hibernate.ddl-auto=create-drop
 jwt.secret=Q2hhbmdlVGhpc1NlY3JldEtleUNoYW5nZVRoaXNTZWNyZXRLZXk=
-google.api.key=${GOOGLE_API_KEY}.
+# Path to OAuth client credentials JSON file
+google.credentials.file=${GOOGLE_CREDENTIALS_FILE}
 


### PR DESCRIPTION
## Summary
- replace API-key based calendar access with OAuth2 credentials using Google's Java client
- store and reuse OAuth tokens on disk, refreshing automatically
- add Google client dependencies and document required Cloud Console setup

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... network is unreachable)*

